### PR TITLE
Add Automerge integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,77 @@
 # Automerge + Grove
 
-TODO:
+## Instructions
+
+Install dependencies
+
+```
+npm install
+```
+
+Then run the dev server:
+
+```
+npm run dev
+```
+
+Now, open the app in the browser. You should see that the location hash in the
+URL is updated with a document ID. If you paste this same URL into another
+window (or another browser, or even another browser on another device), you should
+see the same document and you should see edits being reflected in real time.
+
+If you want to open a new document, remove the hash from the url and reload.
+
+## Automerge Integration
+
+The approach we take to integrating Grove with Automerge is to use Automerge as
+a simple mechanism for transporting grove patches around. I.e. the Automerge
+document looks like this:
+
+```
+{
+  grovePatches: {
+    "<patch ID>": "<JSON serialization of grove patch>"
+  }
+}
+```
+
+### Why JSON serialization?
+
+The reason for using the JSON serialization rather than the actual JSON
+is that it makes it easier to translate the patches which Automerge produces
+into something we can hand to Grove. For composite structures like maps
+and lists Automerge produces very granular patches, for example, the
+patches initializing a document like this:
+
+```
+{
+  foos: [{x: 1, y: 2}]
+}
+```
+
+Would look a like this:
+
+```
+[
+  { action: 'put', path: [ 'foos' ], value: [] },
+  { action: 'insert', path: [ 'foos', 0 ], values: [ {} ] },
+  { action: 'put', path: [ 'foos', 0, 'x' ], value: 1 },
+  { action: 'put', path: [ 'foos', 0, 'y' ], value: 2 }
+]
+```
+
+This is unnecessarily granular for grove patches and would require us to write
+some irritating logic to gather the granular patches into the format Grove
+expects. By using the JSON serialization we get a single patch with the entire
+grove patch in it.
+
+One slight wrinkle is that in Automerge `string` values are actually collaborative
+strings under the hood, which means overhead we don't really want. To get a
+non-collaborative string we use the `Automerge.ImmutableString` class for the
+value of the patch.
+
+## TODO
+
 - Ensure "live" edges are not used where "visible" should be
 - Only allow paste into holes
 - Cycle handling

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
       "name": "autogrove",
       "version": "0.0.0",
       "dependencies": {
+        "@automerge/react": "^2.2.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "uuid": "^11.1.0",
+        "vite-plugin-top-level-await": "^1.6.0",
+        "vite-plugin-wasm": "^3.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -37,6 +41,130 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@automerge/automerge": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-3.1.1.tgz",
+      "integrity": "sha512-x7tZiMBLk4/SKYimVEVl1/wPntT9buGvLOWCey9ZcH8JUsB0dgm49C0S7Ojzgvflcs2hc/YjiXRPcFeFkinIgw==",
+      "license": "MIT"
+    },
+    "node_modules/@automerge/automerge-repo": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo/-/automerge-repo-2.2.0.tgz",
+      "integrity": "sha512-/4cAxnUDPykqdSMJJiJvPlR2VY0JHJnvEoM7fO8qVXwQors34S0VkJEScXRJZExcVhWGhFTwCTWvUbb6hhWQIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge": "2.2.8 - 3",
+        "bs58check": "^3.0.1",
+        "cbor-x": "^1.3.0",
+        "debug": "^4.3.4",
+        "eventemitter3": "^5.0.1",
+        "fast-sha256": "^1.3.0",
+        "uuid": "^9.0.0",
+        "xstate": "^5.9.1"
+      }
+    },
+    "node_modules/@automerge/automerge-repo-network-broadcastchannel": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-network-broadcastchannel/-/automerge-repo-network-broadcastchannel-2.2.0.tgz",
+      "integrity": "sha512-HXVEb2ehQT28iY4ku/7cRZ3GIpKcEsebvDePBX2z/VjUfamVzUPcquS/772VnjQC/4IMWnbx4YcRuPNi5CaYbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge-repo": "2.2.0"
+      }
+    },
+    "node_modules/@automerge/automerge-repo-network-messagechannel": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-network-messagechannel/-/automerge-repo-network-messagechannel-2.2.0.tgz",
+      "integrity": "sha512-rpLsXw7Sw4P4x8O143HXI9jY87WAhxzTyOm0RFmTB49DI88etwsMOG/JKKVvxDwm75EHupmzI0gWgwXcbERdKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge-repo": "2.2.0",
+        "debug": "^4.3.4",
+        "eventemitter3": "^5.0.1"
+      }
+    },
+    "node_modules/@automerge/automerge-repo-network-websocket": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-network-websocket/-/automerge-repo-network-websocket-2.2.0.tgz",
+      "integrity": "sha512-/WQrEVHEzLYlowDasXu/a34F3vTuLx+XmhLN3JKvPGl8GUs1nPn0ePl1nGXtfMgDsqwo8UgeM5T//oqYtKeQxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge-repo": "2.2.0",
+        "cbor-x": "^1.3.0",
+        "debug": "^4.3.4",
+        "eventemitter3": "^5.0.1",
+        "isomorphic-ws": "^5.0.0",
+        "ws": "^8.7.0"
+      }
+    },
+    "node_modules/@automerge/automerge-repo-react-hooks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-react-hooks/-/automerge-repo-react-hooks-2.2.0.tgz",
+      "integrity": "sha512-zHP44jXSCmV1DyyKdTKgv8nz7yrdCT7VFXs/QrF3YRhE/3czhhvbXo2zahGvOoM+jryH0eJxHTrJ7jMEtt/Ung==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge": "2.2.8 - 3",
+        "@automerge/automerge-repo": "2.2.0",
+        "eventemitter3": "^5.0.1",
+        "react-usestateref": "^1.0.8"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@automerge/automerge-repo-storage-indexeddb": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-storage-indexeddb/-/automerge-repo-storage-indexeddb-2.2.0.tgz",
+      "integrity": "sha512-fob5ITgZs36m9ZqCflGsHYjrHUUC1HWCGe0LejLokAfXAk66ia3Pjbpe8IRz99H/Maeny5GpqwQv4/ykAzpMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge-repo": "2.2.0"
+      }
+    },
+    "node_modules/@automerge/automerge-repo/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@automerge/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@automerge/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-lMpYGMlrZiWYTIygIz7zYBe/qsyv4+njA0V8V/kfcmxf8eII1969R2zlGu2lCIYT3Wh7euDVG6/c68WpUj9Wbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge-repo": "2.2.0",
+        "@automerge/automerge-repo-network-broadcastchannel": "2.2.0",
+        "@automerge/automerge-repo-network-messagechannel": "2.2.0",
+        "@automerge/automerge-repo-network-websocket": "2.2.0",
+        "@automerge/automerge-repo-react-hooks": "2.2.0",
+        "@automerge/automerge-repo-storage-indexeddb": "2.2.0",
+        "react": "^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@automerge/react/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -321,6 +449,84 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.0.tgz",
+      "integrity": "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.0.tgz",
+      "integrity": "sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.0.tgz",
+      "integrity": "sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.0.tgz",
+      "integrity": "sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.0.tgz",
+      "integrity": "sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.0.tgz",
+      "integrity": "sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.6",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
@@ -328,7 +534,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -345,7 +550,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -362,7 +566,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -379,7 +582,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -396,7 +598,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -413,7 +614,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -430,7 +630,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -447,7 +646,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -464,7 +662,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -481,7 +678,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,7 +694,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -515,7 +710,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -532,7 +726,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -549,7 +742,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -566,7 +758,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -583,7 +774,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -600,7 +790,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -617,7 +806,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -634,7 +822,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -651,7 +838,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -668,7 +854,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -685,7 +870,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -702,7 +886,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -719,7 +902,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -736,7 +918,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -753,7 +934,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1022,6 +1202,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1067,6 +1259,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-virtual": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
+      "integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.45.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
@@ -1074,7 +1283,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1088,7 +1296,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1102,7 +1309,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1116,7 +1322,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1130,7 +1335,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1144,7 +1348,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1158,7 +1361,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1172,7 +1374,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1186,7 +1387,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1200,7 +1400,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1214,7 +1413,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,7 +1426,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1242,7 +1439,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1256,7 +1452,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1270,7 +1465,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1284,7 +1478,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1298,7 +1491,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1312,7 +1504,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1326,7 +1517,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1340,12 +1530,230 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@swc/core": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.3.tgz",
+      "integrity": "sha512-ZaDETVWnm6FE0fc+c2UE8MHYVS3Fe91o5vkmGfgwGXFbxYvAjKSqxM/j4cRc9T7VZNSJjriXq58XkfCp3Y6f+w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.23"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.13.3",
+        "@swc/core-darwin-x64": "1.13.3",
+        "@swc/core-linux-arm-gnueabihf": "1.13.3",
+        "@swc/core-linux-arm64-gnu": "1.13.3",
+        "@swc/core-linux-arm64-musl": "1.13.3",
+        "@swc/core-linux-x64-gnu": "1.13.3",
+        "@swc/core-linux-x64-musl": "1.13.3",
+        "@swc/core-win32-arm64-msvc": "1.13.3",
+        "@swc/core-win32-ia32-msvc": "1.13.3",
+        "@swc/core-win32-x64-msvc": "1.13.3"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.3.tgz",
+      "integrity": "sha512-ux0Ws4pSpBTqbDS9GlVP354MekB1DwYlbxXU3VhnDr4GBcCOimpocx62x7cFJkSpEBF8bmX8+/TTCGKh4PbyXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.3.tgz",
+      "integrity": "sha512-p0X6yhxmNUOMZrbeZ3ZNsPige8lSlSe1llllXvpCLkKKxN/k5vZt1sULoq6Nj4eQ7KeHQVm81/+AwKZyf/e0TA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.3.tgz",
+      "integrity": "sha512-OmDoiexL2fVWvQTCtoh0xHMyEkZweQAlh4dRyvl8ugqIPEVARSYtaj55TBMUJIP44mSUOJ5tytjzhn2KFxFcBA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.3.tgz",
+      "integrity": "sha512-STfKku3QfnuUj6k3g9ld4vwhtgCGYIFQmsGPPgT9MK/dI3Lwnpe5Gs5t1inoUIoGNP8sIOLlBB4HV4MmBjQuhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.3.tgz",
+      "integrity": "sha512-bc+CXYlFc1t8pv9yZJGus372ldzOVscBl7encUBlU1m/Sig0+NDJLz6cXXRcFyl6ABNOApWeR4Yl7iUWx6C8og==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.3.tgz",
+      "integrity": "sha512-dFXoa0TEhohrKcxn/54YKs1iwNeW6tUkHJgXW33H381SvjKFUV53WR231jh1sWVJETjA3vsAwxKwR23s7UCmUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.3.tgz",
+      "integrity": "sha512-ieyjisLB+ldexiE/yD8uomaZuZIbTc8tjquYln9Quh5ykOBY7LpJJYBWvWtm1g3pHv6AXlBI8Jay7Fffb6aLfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.3.tgz",
+      "integrity": "sha512-elTQpnaX5vESSbhCEgcwXjpMsnUbqqHfEpB7ewpkAsLzKEXZaK67ihSRYAuAx6ewRQTo7DS5iTT6X5aQD3MzMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.3.tgz",
+      "integrity": "sha512-nvehQVEOdI1BleJpuUgPLrclJ0TzbEMc+MarXDmmiRFwEUGqj+pnfkTSb7RZyS1puU74IXdK/YhTirHurtbI9w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.3.tgz",
+      "integrity": "sha512-A+JSKGkRbPLVV2Kwx8TaDAV0yXIXm/gc8m98hSkVDGlPBBmydgzNdWy3X7HTUBM7IDk7YlWE7w2+RUGjdgpTmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.24.tgz",
+      "integrity": "sha512-tjTMh3V4vAORHtdTprLlfoMptu1WfTZG9Rsca6yOKyNYsRr+MUXutKmliB17orgSZk5DpnDxs8GUdd/qwYxOng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@swc/wasm": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.13.3.tgz",
+      "integrity": "sha512-ZhQfKxqFvrifksN8znSzes/oyfr8Q4mpKP0T8tYS/AaUzm/7v5OK22VlcTHR1gXHEtp16dlR8w+vYTFDCaUmnw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1396,7 +1804,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1788,6 +2195,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1845,6 +2258,25 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
+      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^5.0.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1875,6 +2307,37 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cbor-extract": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.0.tgz",
+      "integrity": "sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.1.1"
+      },
+      "bin": {
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.2.0",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.2.0",
+        "@cbor-extract/cbor-extract-linux-arm": "2.2.0",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.2.0",
+        "@cbor-extract/cbor-extract-linux-x64": "2.2.0",
+        "@cbor-extract/cbor-extract-win32-x64": "2.2.0"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.0.tgz",
+      "integrity": "sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "cbor-extract": "^2.2.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1953,7 +2416,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1974,6 +2436,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.185",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.185.tgz",
@@ -1985,7 +2457,6 @@
       "version": "0.25.6",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
       "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2224,6 +2695,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2274,6 +2751,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -2353,7 +2836,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2494,11 +2976,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2608,6 +3098,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2659,14 +3161,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2687,6 +3187,21 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -2782,7 +3297,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2802,7 +3316,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2899,6 +3412,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-usestateref": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/react-usestateref/-/react-usestateref-1.0.9.tgz",
+      "integrity": "sha512-t8KLsI7oje0HzfzGhxFXzuwbf1z9vhBM1ptHLUIHhYqZDKFuI5tzdhEVxSNzUkYxwF8XdpOErzHlKxvP7sTERw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": ">16.0.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2924,7 +3446,6 @@
       "version": "4.45.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
       "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -3027,7 +3548,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3063,7 +3583,6 @@
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
       "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.4.4",
@@ -3080,7 +3599,6 @@
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
       "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"
@@ -3095,7 +3613,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3222,11 +3739,23 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.4.tgz",
       "integrity": "sha512-SkaSguuS7nnmV7mfJ8l81JGBFV7Gvzp8IzgE8A8t23+AxuNX61Q5H1Tpz5efduSN7NHC8nQXD3sKQKZAu5mNEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -3297,11 +3826,47 @@
         }
       }
     },
+    "node_modules/vite-plugin-top-level-await": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.6.0.tgz",
+      "integrity": "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-virtual": "^3.0.2",
+        "@swc/core": "^1.12.14",
+        "@swc/wasm": "^1.12.14",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.8"
+      }
+    },
+    "node_modules/vite-plugin-top-level-await/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.5.0.tgz",
+      "integrity": "sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
       "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"
@@ -3316,7 +3881,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3349,6 +3913,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xstate": {
+      "version": "5.20.2",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.20.2.tgz",
+      "integrity": "sha512-GZmLmc+WPKfFRxuTDAxCg0cUhS/ZnWaRD86DO8MKizeK4a050jd5k7UNnIQ2jJDWRig2/r0tmVXeezUNIhoz5Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@automerge/react": "^2.2.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "uuid": "^11.1.0",
+    "vite-plugin-top-level-await": "^1.6.0",
+    "vite-plugin-wasm": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,42 +1,90 @@
-import { useState, useEffect } from 'react'
-import automergeLogo from './assets/automerge.png'
-import hazelLogo from './assets/hazelnut.png'
-import './App.css'
-import {apply_action, initial_client_state, string_of_state} from './grove'
-import type {action} from './grove'
+import { useCallback, useEffect, useRef, useState } from "react";
+import automergeLogo from "./assets/automerge.png";
+import hazelLogo from "./assets/hazelnut.png";
+import "./App.css";
+import {
+  apply_action,
+  apply_patch,
+  from_patches,
+  string_of_state,
+} from "./grove";
+import type { action } from "./grove";
+import { ImmutableString, DocHandle } from "@automerge/react";
+import {
+  amPatchToGrovePatch,
+  grovePatchesFromDocHandle,
+  type GroveDoc,
+} from "./autogrove";
 
-function App() {
-  const [state, setState] = useState(initial_client_state())
+function App({ handle }: { handle: DocHandle<GroveDoc> }) {
+  const initialState = from_patches(grovePatchesFromDocHandle(handle));
+  // The state is mutated by the apply_action function so we use useRef rather
+  // than useState as useState is designed for immutable values
+  const stateRef = useRef(initialState);
+  const [renderedState, setRenderedState] = useState(
+    string_of_state(initialState),
+  );
 
-  function handleKeyDown(event: KeyboardEvent) {
-    const keyMap: Record<string, action> = {
-      Backspace: { kind: "delete" },
-      "0": { kind: "insert", value: "zero" },
-      "+": { kind: "wrap_left", value: "plus" },
-      "*": { kind: "wrap_left", value: "times"},
-      ArrowUp:   { kind: "move", value: "up" },
-      ArrowDown: { kind: "move", value: "down" },
-      ArrowRight:{ kind: "move", value: "right" },
-      "c": { kind: "copy" },
-      "v": { kind: "paste" },
-    };
-    
-    // console.log(event.key)
-    const action = keyMap[event.key];
-    if (action === undefined) return;
+  // useCallback so that we can declare applyAction as a dependency of the
+  // useEffect hook for the keydown event without causing an infinite loop
+  const applyAction = useCallback(
+    (action: action) => {
+      // Whenever we apply an action, update the state ref, then add any new patches
+      // to the Automerge document. Then update the rendered state
+      const patches = apply_action(stateRef.current, action);
 
-    event.preventDefault();
-    const newState = apply_action(state, action);
-    setState(newState);
-  }
+      handle.change((d) => {
+        for (const patch of patches) {
+          const patchId = `${patch.sign}-${patch.id}`;
+          d.grovePatches[patchId] = new ImmutableString(JSON.stringify(patch));
+        }
+      });
+      setRenderedState(string_of_state(stateRef.current));
+    },
+    [handle, stateRef],
+  );
 
-  function keyboard_effect() {
-    window.addEventListener("keydown", handleKeyDown)
-    return () => window.removeEventListener("keydown", handleKeyDown)
-  }
+  handle.on("change", ({ patches }) => {
+    // Something changed in the automerge document. Convert the incoming patches
+    // to grove patches and apply them to the state, then update the rendered
+    // state. Note that this will happen twice for local changes, once in
+    // applyAction, and then once again here. That's fine, all events are
+    // idempotent
+    if (patches.length == 0) return;
+    for (const amPatch of patches) {
+      const grPatch = amPatchToGrovePatch(amPatch);
+      if (grPatch != null) {
+        apply_patch(stateRef.current.shared_state, grPatch);
+      }
+    }
+    setRenderedState(string_of_state(stateRef.current));
+  });
 
-  useEffect(keyboard_effect, [state])
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      const keyMap: Record<string, action> = {
+        Backspace: { kind: "delete" },
+        "0": { kind: "insert", value: "zero" },
+        "+": { kind: "wrap_left", value: "plus" },
+        "*": { kind: "wrap_left", value: "times" },
+        ArrowUp: { kind: "move", value: "up" },
+        ArrowDown: { kind: "move", value: "down" },
+        ArrowRight: { kind: "move", value: "right" },
+        c: { kind: "copy" },
+        v: { kind: "paste" },
+      };
 
+      // console.log(event.key)
+      const action = keyMap[event.key];
+      if (action === undefined) return;
+
+      event.preventDefault();
+      applyAction(action);
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  });
 
   return (
     <>
@@ -50,44 +98,76 @@ function App() {
       </div>
       <h1>Automerge + Grove</h1>
       <div className="card">
-        <button onClick={() => {var ls = apply_action(state, {kind: "insert", value : "zero"}); setState(ls)}}>
+        <button
+          onClick={() => {
+            applyAction({ kind: "insert", value: "zero" });
+          }}
+        >
           Insert 0
         </button>
-        <button onClick={() => {var ls = apply_action(state, {kind: "wrap_left", value : "plus"}); setState(ls)}}>
+        <button
+          onClick={() => {
+            applyAction({ kind: "wrap_left", value: "plus" });
+          }}
+        >
           Wrap +
         </button>
-        <button onClick={() => {var ls = apply_action(state, {kind: "wrap_left", value : "times"}); setState(ls)}}>
+        <button
+          onClick={() => {
+            applyAction({ kind: "wrap_left", value: "times" });
+          }}
+        >
           Wrap *
         </button>
-        <button onClick={() => {var ls = apply_action(state, {kind: "delete"}); setState(ls)}}>
+        <button
+          onClick={() => {
+            applyAction({ kind: "delete" });
+          }}
+        >
           Delete
         </button>
         <br></br>
-        <button onClick={() => {var ls = apply_action(state, {kind: "move", value : "up"}); setState(ls)}}>
+        <button
+          onClick={() => {
+            applyAction({ kind: "move", value: "up" });
+          }}
+        >
           Move Up
         </button>
-        <button onClick={() => {var ls = apply_action(state, {kind: "move", value : "down"}); setState(ls)}}>
+        <button
+          onClick={() => {
+            applyAction({ kind: "move", value: "down" });
+          }}
+        >
           Move Down
         </button>
-        <button onClick={() => {var ls = apply_action(state, {kind: "move", value : "right"}); setState(ls)}}>
+        <button
+          onClick={() => {
+            applyAction({ kind: "move", value: "right" });
+          }}
+        >
           Move Right
         </button>
         <br></br>
-        <button onClick={() => {var ls = apply_action(state, {kind: "copy"}); setState(ls)}}>
+        <button
+          onClick={() => {
+            applyAction({ kind: "copy" });
+          }}
+        >
           Copy
         </button>
-        <button onClick={() => {var ls = apply_action(state, {kind: "paste"}); setState(ls)}}>
+        <button
+          onClick={() => {
+            applyAction({ kind: "paste" });
+          }}
+        >
           Paste
         </button>
-        <p>
-          Program: {string_of_state(state)}
-        </p>
+        <p>Program: {renderedState}</p>
       </div>
-      <p className="read-the-docs">
-        Click on the logos to learn more
-      </p>
+      <p className="read-the-docs">Click on the logos to learn more</p>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,10 @@ function App({ handle }: { handle: DocHandle<GroveDoc> }) {
     (action: action) => {
       // Whenever we apply an action, update the state ref, then add any new patches
       // to the Automerge document. Then update the rendered state
-      const patches = apply_action(stateRef.current, action);
+      const { local_state, patches } = apply_action(stateRef.current, action);
+      stateRef.current.local_state = local_state;
+      console.log("local state in applyAction: ", stateRef.current.local_state);
+      console.log(string_of_state(stateRef.current));
 
       handle.change((d) => {
         for (const patch of patches) {

--- a/src/autogrove.ts
+++ b/src/autogrove.ts
@@ -1,0 +1,88 @@
+import {
+  type Patch as AmPatch,
+  isImmutableString,
+  ImmutableString,
+  DocHandle,
+} from "@automerge/react";
+import type { patch } from "./grove";
+
+/**
+ * The shape of the log of patches stored in an Automerge documents
+ *
+ */
+export type GroveDoc = {
+  /**
+   * A map from (unique) patch ID to the JSON serialization of the patch
+   */
+  grovePatches: {
+    [patchId: string]: ImmutableString;
+  };
+};
+
+export function groveToAutomerge(
+  patches: patch[],
+  handle: DocHandle<GroveDoc>,
+) {
+  handle.change((d) => {
+    for (const patch of patches) {
+      // Patches are either additions or removals of an edge, so by
+      // appending the sign to the edge ID we get a unique patch ID
+      const patchId = `${patch.sign}-${patch.id}`;
+      d.grovePatches[patchId] = new ImmutableString(JSON.stringify(patch));
+    }
+  });
+}
+
+export function grovePatchesFromDocHandle(doc: DocHandle<GroveDoc>): patch[] {
+  const result = [];
+  for (const [_patchId, serializedPatch] of Object.entries(
+    doc.doc().grovePatches,
+  )) {
+    try {
+      const patch = JSON.parse(serializedPatch.toString());
+      result.push(patch);
+    } catch (error) {
+      console.error(`Error parsing patch ${_patchId}: ${error}`);
+    }
+  }
+  return result;
+}
+
+/**
+ * Convert an Automerge patch to a grove patch
+ *
+ * @param amPatch - A patch emitted by Automerge
+ * @returns A grove patch if there was one corresponding to the Automerge patch
+ */
+export function amPatchToGrovePatch(amPatch: AmPatch): patch | undefined {
+  // The automerge document contains a map of the form:
+  //
+  // {
+  //   "grovePatches": {
+  //       "<patchId>": ImmutableString("<JSON serialized patch>")
+  //    }
+  // }
+  //
+  // Which means that automerge will emit only one kind of patch we care about,
+  // a "put" patch, which will look like this:
+  //
+  // {
+  //     action: "put",
+  //     path: ["grovePatches", "<patchid>"]
+  //     value: ImmutableString("<JSON serialized patch>")
+  // }
+  if (
+    amPatch.action === "put" &&
+    amPatch.path[0] === "grovePatches" &&
+    amPatch.path.length === 2 &&
+    typeof amPatch.path[1] === "string"
+  ) {
+    // const patchId = amPatch.path[1];
+    if (!isImmutableString(amPatch.value)) {
+      throw new Error("patches should be an ImmutableString");
+    }
+    const patch = JSON.parse(amPatch.value.val);
+    return patch;
+  }
+  return;
+}

--- a/src/grove.ts
+++ b/src/grove.ts
@@ -1,44 +1,48 @@
 // import { Children } from "react";
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from "uuid";
 
-type NodeId = string & { __brand: 'NodeId' }
-type EdgeId = string & { __brand: 'EdgeId' }
+type NodeId = string & { __brand: "NodeId" };
+type EdgeId = string & { __brand: "EdgeId" };
 
 const ROOT_NODE_ID = "ROOT" as NodeId;
 
-function min_node(n1 : NodeId, n2 : NodeId): NodeId {
-    if (n1 < n2) {
-        return n1;
-    }
-    return n2;
+function min_node(n1: NodeId, n2: NodeId): NodeId {
+  if (n1 < n2) {
+    return n1;
+  }
+  return n2;
 }
 
 type position = number;
-type location = [NodeId, position]
+type location = [NodeId, position];
 
-function location_equal(l1 : location, l2 : location): boolean {
-    return l1[0] === l2[0] && l1[1] == l2[1]
+function location_equal(l1: location, l2: location): boolean {
+  return l1[0] === l2[0] && l1[1] == l2[1];
 }
 
-type sign = "live" | "dead"
+type sign = "live" | "dead";
 
-function sign_join(s1 : sign, s2 : sign) : sign {
-    return s1 === "live" ? s2 : "dead";
+function sign_join(s1: sign, s2: sign): sign {
+  return s1 === "live" ? s2 : "dead";
 }
 
-type constructor = "root" | "plus" | "times" | "zero"
+type constructor = "root" | "plus" | "times" | "zero";
 
-function arity(c : constructor): position {
-    switch(c) {
-        case "root": return 1; 
-        case "plus": return 2;
-        case "times": return 2;
-        case "zero": return 0;
-    }
+function arity(c: constructor): position {
+  switch (c) {
+    case "root":
+      return 1;
+    case "plus":
+      return 2;
+    case "times":
+      return 2;
+    case "zero":
+      return 0;
+  }
 }
 
-type nodemap<A> = Map<NodeId, A>
-type edgemap<A> = Map<EdgeId, A>
+type nodemap<A> = Map<NodeId, A>;
+type edgemap<A> = Map<EdgeId, A>;
 
 function string_of_map<K, V>(m: Map<K, V>): string {
   return Array.from(m)
@@ -51,340 +55,380 @@ function string_of_map<K, V>(m: Map<K, V>): string {
 // }
 
 type state = {
-    root: NodeId
-    parents: nodemap<EdgeId[]>
-    children: nodemap<EdgeId[][]>
-    constructor: nodemap<constructor>
-    source: edgemap<location>
-    destination: edgemap<NodeId>
-    sign: edgemap<sign>
-    // incremental decomp
-    is_root : nodemap<boolean>
-    in_unicycle : nodemap<boolean>
-}
+  root: NodeId;
+  parents: nodemap<EdgeId[]>;
+  children: nodemap<EdgeId[][]>;
+  constructor: nodemap<constructor>;
+  source: edgemap<location>;
+  destination: edgemap<NodeId>;
+  sign: edgemap<sign>;
+  // incremental decomp
+  is_root: nodemap<boolean>;
+  in_unicycle: nodemap<boolean>;
+};
 
-function get_new_edge() : EdgeId {
+function get_new_edge(): EdgeId {
   return uuidv4() as EdgeId;
 }
 
-function get_new_node() : NodeId {
+function get_new_node(): NodeId {
   return uuidv4() as NodeId;
 }
 
-function is_root_of_node(s : state, n : NodeId): boolean {
-    const is_root = s.is_root.get(n);
-    if (is_root === undefined) throw new Error("Node without is_root");
-    return is_root;
+function is_root_of_node(s: state, n: NodeId): boolean {
+  const is_root = s.is_root.get(n);
+  if (is_root === undefined) throw new Error("Node without is_root");
+  return is_root;
 }
 
-function in_unicycle_of_node(s : state, n : NodeId): boolean {
-    const in_unicycle = s.in_unicycle.get(n);
-    if (in_unicycle === undefined) throw new Error("Node without in_unicycle");
-    return in_unicycle;
+function in_unicycle_of_node(s: state, n: NodeId): boolean {
+  const in_unicycle = s.in_unicycle.get(n);
+  if (in_unicycle === undefined) throw new Error("Node without in_unicycle");
+  return in_unicycle;
 }
 
-function filter_live(s : state, es : EdgeId[]) : EdgeId[] {
-    return es.filter(e => sign_of_edge(s, e) === "live");
+function filter_live(s: state, es: EdgeId[]): EdgeId[] {
+  return es.filter((e) => sign_of_edge(s, e) === "live");
 }
 
 // function is_visible(s : state, e : edge) : boolean {
 //     return sign_of_edge(s, e) === "live" && !is_root_of_node(s, destination_of_edge(s, e))
 // }
 
-function filter_visible(s : state, es : EdgeId[]) : EdgeId[] {
-    return es.filter(e => sign_of_edge(s, e) === "live");
+function filter_visible(s: state, es: EdgeId[]): EdgeId[] {
+  return es.filter((e) => sign_of_edge(s, e) === "live");
 }
 
-
-function parents_of_node(s : state, n : NodeId): EdgeId[] {
-    const parents = s.parents.get(n);
-    if (parents === undefined) throw new Error("Node without parents");
-    return parents;
+function parents_of_node(s: state, n: NodeId): EdgeId[] {
+  const parents = s.parents.get(n);
+  if (parents === undefined) throw new Error("Node without parents");
+  return parents;
 }
 
-function parent_of_node(s : state, n : NodeId): EdgeId | undefined {
-    var parents = parents_of_node(s, n);
-    var live_parents = filter_live(s, parents);
-    if (live_parents.length === 1) return live_parents[0];
-    return undefined
+function parent_of_node(s: state, n: NodeId): EdgeId | undefined {
+  var parents = parents_of_node(s, n);
+  var live_parents = filter_live(s, parents);
+  if (live_parents.length === 1) return live_parents[0];
+  return undefined;
 }
 
-function unique_parent_of_node(s : state, n : NodeId): EdgeId {
-    var parent = parent_of_node(s, n);
-    if (parent === undefined) throw new Error("Non-unique parent of node")
-    return parent
+function unique_parent_of_node(s: state, n: NodeId): EdgeId {
+  var parent = parent_of_node(s, n);
+  if (parent === undefined) throw new Error("Non-unique parent of node");
+  return parent;
 }
 
-function children_of_node(s : state, n : NodeId): EdgeId[][] {
-    const children = s.children.get(n);
-    if (children === undefined) throw new Error("Node without children");
-    return children;
+function children_of_node(s: state, n: NodeId): EdgeId[][] {
+  const children = s.children.get(n);
+  if (children === undefined) throw new Error("Node without children");
+  return children;
 }
 
-function live_children_of_location(s : state, l : location): EdgeId[] {
-    var [n, p] = l;
-    var children = children_of_node(s, n);
-    if (p > children.length) throw new Error("Illegal location");
-    return filter_live(s, children[p]);
+function live_children_of_location(s: state, l: location): EdgeId[] {
+  var [n, p] = l;
+  var children = children_of_node(s, n);
+  if (p > children.length) throw new Error("Illegal location");
+  return filter_live(s, children[p]);
 }
 
-function right_sibling_of_node(s : state, n : NodeId): NodeId {
-    var parent = parent_of_node(s, n);
-    if (parent === undefined) return n;
-    var source = source_of_edge(s, parent);
-    var local_siblings = live_children_of_location(s, source);
-    var index = local_siblings.findIndex(e => e === parent);
-    var next_index = (index + 1) % local_siblings.length;   
-    var next_edge = local_siblings[next_index];
-    return destination_of_edge(s, next_edge);
+function right_sibling_of_node(s: state, n: NodeId): NodeId {
+  var parent = parent_of_node(s, n);
+  if (parent === undefined) return n;
+  var source = source_of_edge(s, parent);
+  var local_siblings = live_children_of_location(s, source);
+  var index = local_siblings.findIndex((e) => e === parent);
+  var next_index = (index + 1) % local_siblings.length;
+  var next_edge = local_siblings[next_index];
+  return destination_of_edge(s, next_edge);
 }
 
-function right_sibling_of_location(s : state, l : location): location {
-    var [n, p] = l;
-    var children = children_of_node(s, n);
-    return [n, (p + 1) % children.length]
+function right_sibling_of_location(s: state, l: location): location {
+  var [n, p] = l;
+  var children = children_of_node(s, n);
+  return [n, (p + 1) % children.length];
 }
 
-function constructor_of_node(s : state, n : NodeId): constructor {
-    const constructor = s.constructor.get(n);
-    if (constructor === undefined) throw new Error("Node without destination");
-    return constructor;
+function constructor_of_node(s: state, n: NodeId): constructor {
+  const constructor = s.constructor.get(n);
+  if (constructor === undefined) throw new Error("Node without destination");
+  return constructor;
 }
 
-function source_of_edge(s : state, e : EdgeId): location {
-    const source = s.source.get(e);
-    if (source === undefined) throw new Error("Edge without source");
-    return source;
+function source_of_edge(s: state, e: EdgeId): location {
+  const source = s.source.get(e);
+  if (source === undefined) throw new Error("Edge without source");
+  return source;
 }
 
-function destination_of_edge(s : state, e : EdgeId): NodeId {
-    const node = s.destination.get(e);
-    if (node === undefined) throw new Error("Edge without destination");
-    return node;
+function destination_of_edge(s: state, e: EdgeId): NodeId {
+  const node = s.destination.get(e);
+  if (node === undefined) throw new Error("Edge without destination");
+  return node;
 }
 
-function sign_of_edge(s : state, e : EdgeId): sign {
-    const sign = s.sign.get(e);
-    if (sign === undefined) throw new Error("Edge without sign");
-    return sign;
+function sign_of_edge(s: state, e: EdgeId): sign {
+  const sign = s.sign.get(e);
+  if (sign === undefined) throw new Error("Edge without sign");
+  return sign;
 }
 
 type patch_node = [NodeId, constructor];
-type patch_location = [patch_node, position]
+type patch_location = [patch_node, position];
 
 export type patch = {
-    id: EdgeId,
-    source: patch_location,
-    destination: patch_node,
-    sign: sign,
+  id: EdgeId;
+  source: patch_location;
+  destination: patch_node;
+  sign: sign;
+};
+
+function create_patch_node_if_new(s: state, n: patch_node) {
+  var [id, c] = n;
+  if (s.constructor.get(id) !== undefined) return;
+  s.parents.set(id, []);
+  s.children.set(
+    id,
+    Array.from({ length: arity(c) }, () => []),
+  );
+  s.constructor.set(id, c);
 }
 
-function create_patch_node_if_new(s : state, n : patch_node) {
-    var [id , c] = n;
-    if (s.constructor.get(id) !== undefined) return;
-    s.parents.set(id, []);
-    s.children.set(id, Array.from({ length: arity(c) }, () => []));
-    s.constructor.set(id, c)
+function connect_edge_source(s: state, e: EdgeId) {
+  var source = source_of_edge(s, e);
+  var [n, p] = source;
+  var old_children = children_of_node(s, n);
+  if (p >= old_children.length) throw new Error("Invalid child position");
+  var map_child = (childEdges: EdgeId[], i: number) =>
+    i === p ? [e, ...childEdges] : childEdges;
+  var new_children = old_children.map(map_child);
+  s.children.set(n, new_children);
 }
 
-function connect_edge_source(s : state, e : EdgeId) {
-    var source = source_of_edge(s, e);
-    var [n, p] = source;
-    var old_children = children_of_node(s, n);
-    if (p >= old_children.length) throw new Error("Invalid child position");
-    var map_child = (childEdges : EdgeId[], i : number) => i === p ? [e, ...childEdges] : childEdges;
-    var new_children = old_children.map(map_child);
-    s.children.set(n, new_children);
+function connect_edge_destination(s: state, e: EdgeId) {
+  var destination = destination_of_edge(s, e);
+  var old_parents = parents_of_node(s, destination);
+  s.parents.set(destination, [e, ...old_parents]);
 }
 
-function connect_edge_destination(s : state, e : EdgeId) {
-    var destination = destination_of_edge(s, e);
-    var old_parents = parents_of_node(s, destination);
-    s.parents.set(destination, [e, ...old_parents])
+function create_edge(s: state, p: patch) {
+  var [[source_id, _], source_p] = p.source;
+  var [destination_id, _] = p.destination;
+  s.source.set(p.id, [source_id, source_p]);
+  s.destination.set(p.id, destination_id);
+  s.sign.set(p.id, p.sign);
+  connect_edge_source(s, p.id);
+  connect_edge_destination(s, p.id);
 }
 
-function create_edge(s : state, p : patch) {
-    var [[source_id, _], source_p] = p.source;
-    var [destination_id, _] = p.destination;
-    s.source.set(p.id, [source_id, source_p]);
-    s.destination.set(p.id, destination_id);
-    s.sign.set(p.id, p.sign);
-    connect_edge_source(s, p.id);
-    connect_edge_destination(s, p.id);
-}
-
-function root_of_node(s : state, n : NodeId) : NodeId {
-    if (is_root_of_node(s, n)) return n
-    var parent = unique_parent_of_node(s, n)
-    return root_of_node(s, source_of_edge(s, parent)[0]);
+function root_of_node(s: state, n: NodeId): NodeId {
+  if (is_root_of_node(s, n)) return n;
+  var parent = unique_parent_of_node(s, n);
+  return root_of_node(s, source_of_edge(s, parent)[0]);
 }
 
 // rolling a node that's now part of a unicycle updates the
 // [is_root] and [in_unicycle] fields for each node in the unicycle.
-function roll(s : state, n : NodeId) {
-    function loop(current_n : NodeId, min_n : NodeId, first : boolean) {
-        if(current_n !== n || first) {
-            s.in_unicycle.set(current_n, true)
-            var new_n = source_of_edge(s, unique_parent_of_node(s, current_n))[0];
-            var new_min_n = min_node(new_n, min_n);
-            return loop(new_n, new_min_n, false);
-        }
-        s.is_root.set(min_n, true)
+function roll(s: state, n: NodeId) {
+  function loop(current_n: NodeId, min_n: NodeId, first: boolean) {
+    if (current_n !== n || first) {
+      s.in_unicycle.set(current_n, true);
+      var new_n = source_of_edge(s, unique_parent_of_node(s, current_n))[0];
+      var new_min_n = min_node(new_n, min_n);
+      return loop(new_n, new_min_n, false);
     }
-    loop(n, n, true)
+    s.is_root.set(min_n, true);
+  }
+  loop(n, n, true);
 }
 
 // unrolling a node that's no longer part of a unicycle updates the
 // [is_root] and [in_unicycle] fields between
 // [start_n] and its ancestor [end_n].
-function unroll(s : state, start_n : NodeId, end_n : NodeId) {
-    s.is_root.set(start_n, false);
-    s.in_unicycle.set(start_n, false);
-    var next_n = source_of_edge(s, unique_parent_of_node(s, start_n))[0];
-    if(start_n !== end_n) unroll(s, next_n, end_n)
+function unroll(s: state, start_n: NodeId, end_n: NodeId) {
+  s.is_root.set(start_n, false);
+  s.in_unicycle.set(start_n, false);
+  var next_n = source_of_edge(s, unique_parent_of_node(s, start_n))[0];
+  if (start_n !== end_n) unroll(s, next_n, end_n);
 }
 
-function deaden_edge(s : state, e : EdgeId) {
-    var source = source_of_edge(s, e);
-    var destination = destination_of_edge(s, e);
-    var parents = filter_live(s, parents_of_node(s, destination));
-    if (parents.length === 0) {
-        if(in_unicycle_of_node(s, destination)) unroll(s, source[0], destination);
-        s.is_root.set(destination, true)   
-    } else if (parents.length === 1) {
-        var parent = parents[0];
-        liven_edge(s, parent);
-    }
+function deaden_edge(s: state, e: EdgeId) {
+  var source = source_of_edge(s, e);
+  var destination = destination_of_edge(s, e);
+  var parents = filter_live(s, parents_of_node(s, destination));
+  if (parents.length === 0) {
+    if (in_unicycle_of_node(s, destination)) unroll(s, source[0], destination);
+    s.is_root.set(destination, true);
+  } else if (parents.length === 1) {
+    var parent = parents[0];
+    liven_edge(s, parent);
+  }
 }
 
-function liven_edge(s : state, e : EdgeId) {
-    var source = source_of_edge(s, e);
-    var destination = destination_of_edge(s, e)
-    var parents = filter_live(s, parents_of_node(s, destination));
-    // if there used to be no parents
-    if (parents.length === 1) {
-        var root_of_source = root_of_node(s, source[0]);
-        s.is_root.set(destination, false)
-        if (root_of_source === destination) {
-            roll(s, source[0])
-        }
+function liven_edge(s: state, e: EdgeId) {
+  var source = source_of_edge(s, e);
+  var destination = destination_of_edge(s, e);
+  var parents = filter_live(s, parents_of_node(s, destination));
+  // if there used to be no parents
+  if (parents.length === 1) {
+    var root_of_source = root_of_node(s, source[0]);
+    s.is_root.set(destination, false);
+    if (root_of_source === destination) {
+      roll(s, source[0]);
     }
-    // if there used to be one parent
-    else if (parents.length === 2) {
-        if (in_unicycle_of_node(s, destination)) {
-            var other_parents = parents.filter(_e => _e !== e);
-            if (other_parents.length !== 1) throw new Error("Edge counting error")
-            var other_parent = source_of_edge(s, other_parents[0])[0];
-            unroll(s, other_parent, destination)
-        }
-        s.is_root.set(destination, true)
+  }
+  // if there used to be one parent
+  else if (parents.length === 2) {
+    if (in_unicycle_of_node(s, destination)) {
+      var other_parents = parents.filter((_e) => _e !== e);
+      if (other_parents.length !== 1) throw new Error("Edge counting error");
+      var other_parent = source_of_edge(s, other_parents[0])[0];
+      unroll(s, other_parent, destination);
     }
+    s.is_root.set(destination, true);
+  }
 }
 
-export function apply_patch(s : state, p : patch) {
-    var old_sign = s.sign.get(p.id);
-    if (old_sign === undefined) {
-        create_patch_node_if_new(s, p.source[0]);
-        create_patch_node_if_new(s, p.destination);
-        create_edge(s, p);
-        // if(p.sign === "live") {
-        //     liven_edge(s, p.id)
-        // }
-    } else {
-        s.sign.set(p.id, sign_join(old_sign, p.sign))
-        // if(p.sign === "dead" && old_sign === "live") {
-        //     deaden_edge(s, p.id)
-        // }
-    }
+export function apply_patch(s: state, p: patch) {
+  var old_sign = s.sign.get(p.id);
+  if (old_sign === undefined) {
+    create_patch_node_if_new(s, p.source[0]);
+    create_patch_node_if_new(s, p.destination);
+    create_edge(s, p);
+    // if(p.sign === "live") {
+    //     liven_edge(s, p.id)
+    // }
+  } else {
+    s.sign.set(p.id, sign_join(old_sign, p.sign));
+    // if(p.sign === "dead" && old_sign === "live") {
+    //     deaden_edge(s, p.id)
+    // }
+  }
 }
 
-export function initial_client_state(): { state: client_state, patches: patch[] } {
-    var s: state = {
-        root: ROOT_NODE_ID,
-        parents: new Map([[ROOT_NODE_ID, []]]),
-        children: new Map([[ROOT_NODE_ID, [[]]]]),
-        constructor: new Map([[ROOT_NODE_ID, "root"]]),
-        source: new Map(),
-        destination: new Map(),
-        sign: new Map(),
-        is_root : new Map([[ROOT_NODE_ID, true]]),
-        in_unicycle : new Map([[ROOT_NODE_ID, false]]),
-    };
-    var c : cursor = { kind: "node", value: get_new_node() };
-    var p : patch = {
-        id : get_new_edge(),
-        source: [[s.root, "root"], 0],
-        destination: [c.value, "zero"],
-        sign: "live",
-    }
-    apply_patch(s, p)
-    return {
-      state: { shared_state: s, local_state: { cursor: c, clipboard: undefined } },
-      patches: [p],
-    }
+export function initial_client_state(): {
+  state: client_state;
+  patches: patch[];
+} {
+  var s: state = {
+    root: ROOT_NODE_ID,
+    parents: new Map([[ROOT_NODE_ID, []]]),
+    children: new Map([[ROOT_NODE_ID, [[]]]]),
+    constructor: new Map([[ROOT_NODE_ID, "root"]]),
+    source: new Map(),
+    destination: new Map(),
+    sign: new Map(),
+    is_root: new Map([[ROOT_NODE_ID, true]]),
+    in_unicycle: new Map([[ROOT_NODE_ID, false]]),
+  };
+  var c: cursor = { kind: "node", value: get_new_node() };
+  var p: patch = {
+    id: get_new_edge(),
+    source: [[s.root, "root"], 0],
+    destination: [c.value, "zero"],
+    sign: "live",
+  };
+  apply_patch(s, p);
+  return {
+    state: {
+      shared_state: s,
+      local_state: { cursor: c, clipboard: undefined },
+    },
+    patches: [p],
+  };
 }
 
-export function from_patches(patches: patch[]) : client_state {
-    const { state } = initial_client_state()
-    for (const patch of patches) {
-      apply_patch(state.shared_state, patch)
-    }
-    return state
+export function from_patches(patches: patch[]): client_state {
+  const { state } = initial_client_state();
+  for (const patch of patches) {
+    apply_patch(state.shared_state, patch);
+  }
+  return state;
 }
 
-const cursor_single : string =  "🫵";
-const root_cursor_single : string = "🥺👉👈";
-function cursor_wrap(str : string) : string { return "👉" + str + "👈" }
-function clipboard_wrap(str : string) : string { return "🫸" + str + "🫷" }
-
-function string_of_edge_set(s : state, es : edge[], l : location, ls : local_state) : string {
-    var wrap = (str : string) => {
-        if(ls.clipboard !== undefined && ls.clipboard.kind === "location" && location_equal(ls.clipboard.value,l)) str = clipboard_wrap(str)
-        if(ls.cursor.kind === "location" && location_equal(ls.cursor.value,l)) {
-            if(str === "?") {
-                if(l[0] === s.root) str = root_cursor_single
-                else str = cursor_single
-            }
-            else str = cursor_wrap(str)
-        }
-        return str
-    };
-    var filtered_edges = filter_visible(s, es);
-    switch (filtered_edges.length) {
-        case 0: return wrap("?")
-        case 1: return wrap(string_of_node(s, destination_of_edge(s, filtered_edges[0]), ls))
-        default: 
-            var strings = filtered_edges.map(e => {return string_of_node(s, destination_of_edge(s, e), ls)})
-            return wrap("{" + strings.join("|") + "}");
-    }   
+const cursor_single: string = "🫵";
+const root_cursor_single: string = "🥺👉👈";
+function cursor_wrap(str: string): string {
+  return "👉" + str + "👈";
+}
+function clipboard_wrap(str: string): string {
+  return "🫸" + str + "🫷";
 }
 
-function string_of_node(s : state, n : node, ls : local_state): string {
-    var wrap = (str : string) => {
-        if(ls.clipboard !== undefined && ls.clipboard.kind === "node" && ls.clipboard.value === n) str = clipboard_wrap(str)
-        if(ls.cursor.kind === "node" && ls.cursor.value === n) str = cursor_wrap(str)
-        return str
-    };
-    var constructor = constructor_of_node(s, n);
-    var children = children_of_node(s, n);
-    if (children.length !== arity(constructor)) {
-        throw new Error("Constructor arity failure");
+function string_of_edge_set(
+  s: state,
+  es: edge[],
+  l: location,
+  ls: local_state,
+): string {
+  var wrap = (str: string) => {
+    if (
+      ls.clipboard !== undefined &&
+      ls.clipboard.kind === "location" &&
+      location_equal(ls.clipboard.value, l)
+    )
+      str = clipboard_wrap(str);
+    if (ls.cursor.kind === "location" && location_equal(ls.cursor.value, l)) {
+      if (str === "?") {
+        if (l[0] === s.root) str = root_cursor_single;
+        else str = cursor_single;
+      } else str = cursor_wrap(str);
     }
-    var children_strings = children.map((es, i) => string_of_edge_set(s, es, [n, i], ls));
-    switch (constructor) {
-        case "root":
-            return wrap(children_strings[0])
-        case "plus":
-            return wrap("(" + children_strings[0] + " + " + children_strings[1] + ")")
-        case "times":
-            return wrap("(" + children_strings[0] + " * " + children_strings[1] + ")")
-        case "zero":
-            return wrap("0");
-    }
+    return str;
+  };
+  var filtered_edges = filter_visible(s, es);
+  switch (filtered_edges.length) {
+    case 0:
+      return wrap("?");
+    case 1:
+      return wrap(
+        string_of_node(s, destination_of_edge(s, filtered_edges[0]), ls),
+      );
+    default:
+      var strings = filtered_edges.map((e) => {
+        return string_of_node(s, destination_of_edge(s, e), ls);
+      });
+      return wrap("{" + strings.join("|") + "}");
+  }
+}
+
+function string_of_node(s: state, n: node, ls: local_state): string {
+  var wrap = (str: string) => {
+    if (
+      ls.clipboard !== undefined &&
+      ls.clipboard.kind === "node" &&
+      ls.clipboard.value === n
+    )
+      str = clipboard_wrap(str);
+    if (ls.cursor.kind === "node" && ls.cursor.value === n)
+      str = cursor_wrap(str);
+    return str;
+  };
+  var constructor = constructor_of_node(s, n);
+  var children = children_of_node(s, n);
+  if (children.length !== arity(constructor)) {
+    throw new Error("Constructor arity failure");
+  }
+  var children_strings = children.map((es, i) =>
+    string_of_edge_set(s, es, [n, i], ls),
+  );
+  switch (constructor) {
+    case "root":
+      return wrap(children_strings[0]);
+    case "plus":
+      return wrap(
+        "(" + children_strings[0] + " + " + children_strings[1] + ")",
+      );
+    case "times":
+      return wrap(
+        "(" + children_strings[0] + " * " + children_strings[1] + ")",
+      );
+    case "zero":
+      return wrap("0");
+  }
 }
 
 export function string_of_state(cs: client_state): string {
-    return string_of_node(cs.shared_state, cs.shared_state.root, cs.local_state)
+  return string_of_node(cs.shared_state, cs.shared_state.root, cs.local_state);
 }
 
 type cursor =
@@ -392,191 +436,221 @@ type cursor =
   | { kind: "location"; value: location };
 
 type local_state = {
-    cursor : cursor,
-    clipboard : cursor | undefined,
-}
+  cursor: cursor;
+  clipboard: cursor | undefined;
+};
 export type client_state = {
-    shared_state : state, 
-    local_state : local_state
+  shared_state: state;
+  local_state: local_state;
 };
 
-type direction = "up" | "down" | "right"
+type direction = "up" | "down" | "right";
 
-export type action = 
-    | {kind: "wrap_left", value : constructor} 
-    | {kind: "insert", value : constructor} 
-    | {kind: "delete"} 
-    | {kind: "move", value : direction} 
-    | {kind: "copy"} 
-    | {kind: "paste"} 
+export type action =
+  | { kind: "wrap_left"; value: constructor }
+  | { kind: "insert"; value: constructor }
+  | { kind: "delete" }
+  | { kind: "move"; value: direction }
+  | { kind: "copy" }
+  | { kind: "paste" };
 
-function patch_node_of_node(s : state, n : node) : patch_node {
-    var c = constructor_of_node(s, n);
-    return [n, c];
+function patch_node_of_node(s: state, n: node): patch_node {
+  var c = constructor_of_node(s, n);
+  return [n, c];
 }
 
-function patch_location_of_location(s : state, l : location) : patch_location {
-    var [n, p] = l;
-    return [patch_node_of_node(s, n), p];
+function patch_location_of_location(s: state, l: location): patch_location {
+  var [n, p] = l;
+  return [patch_node_of_node(s, n), p];
 }
 
-function delete_edge(s : state, e : edge) : patch {
-    var source = patch_location_of_location(s, source_of_edge(s, e))
-    var destination = patch_node_of_node(s, destination_of_edge(s, e))
-    return {
-        id: e,
-        source: source,
-        destination: destination,
-        sign: "dead"
-    }
+function delete_edge(s: state, e: edge): patch {
+  var source = patch_location_of_location(s, source_of_edge(s, e));
+  var destination = patch_node_of_node(s, destination_of_edge(s, e));
+  return {
+    id: e,
+    source: source,
+    destination: destination,
+    sign: "dead",
+  };
 }
 
-function delete_edges(s : state, es : edge[]) : patch[] {
-    return es.map(e => delete_edge(s, e))
+function delete_edges(s: state, es: edge[]): patch[] {
+  return es.map((e) => delete_edge(s, e));
 }
 
-function delete_node(s : state, n : node) : patch[] {
-    return delete_edges(s, filter_live(s, parents_of_node(s, n)))
+function delete_node(s: state, n: node): patch[] {
+  return delete_edges(s, filter_live(s, parents_of_node(s, n)));
 }
 
-function delete_location(s : state, l : location) : patch[] {
-    return delete_edges(s, live_children_of_location(s, l))
+function delete_location(s: state, l: location): patch[] {
+  return delete_edges(s, live_children_of_location(s, l));
 }
 
-function connect(s : state, source : patch_location, destination : patch_node) : patch {
-    return {
-        id: get_new_edge(),
-        source: source,
-        destination: destination,
-        sign: "live"
-    }
+function connect(
+  s: state,
+  source: patch_location,
+  destination: patch_node,
+): patch {
+  return {
+    id: get_new_edge(),
+    source: source,
+    destination: destination,
+    sign: "live",
+  };
 }
 
-function connect_existing(s : state, l : location, n : node) : patch {
-    var source = patch_location_of_location(s, l);
-    var destination = patch_node_of_node(s, n);
-    return connect(s, source, destination)
+function connect_existing(s: state, l: location, n: node): patch {
+  var source = patch_location_of_location(s, l);
+  var destination = patch_node_of_node(s, n);
+  return connect(s, source, destination);
 }
 
-function patches_of_action(cs : client_state, a : action) : [patch[], local_state] {
-    var s = cs.shared_state;
-    var ls = cs.local_state;
-    var c = ls.cursor;
-    const noop : [patch[], local_state] = [[], ls];
-    switch(a.kind) {
-        case "move": return noop;
-        case "copy": return noop;
-        case "delete":
-            if (c.kind === "node") {
-                var ps = delete_node(s, c.value)
-                var live_parents = filter_live(s, parents_of_node(s, c.value));
-                if (live_parents.length === 0) throw new Error("Selected node has no live parents");
-                var location = source_of_edge(s, live_parents[0])
-                return [ps, {"cursor": {"kind": "location", "value": location}, "clipboard" : ls.clipboard}]
-            } else {
-                var ps = delete_location(s, c.value)
-                return [ps, ls]
-            }
-        case "insert": 
-            if (c.kind === "node") return noop;
-            var children = live_children_of_location(s, c.value);
-            if (children.length > 0) return noop;
-            var new_node = get_new_node();
-            var new_patch_node : patch_node = [new_node, a.value];
-            var source : patch_location = patch_location_of_location(s, c.value)
-            var patch : patch = connect(s, source, new_patch_node)
-            return [[patch], ls]
-        case "wrap_left": 
-            if (arity(a.value) === 0) return noop;
-            if (c.kind === "node") {
-                var new_node = get_new_node();
-                var new_patch_node : patch_node = [new_node, a.value];
-                var new_source : patch_location = [new_patch_node, 0];
-                var new_desintation : patch_node = patch_node_of_node(s, c.value)
-                var lower_live_patch : patch = connect(s, new_source, new_desintation)
-                var deletion_patches = delete_node(s, c.value);
-                ps = [lower_live_patch, ...deletion_patches]; 
-            
-                for (var parent of filter_live(s, parents_of_node(s, c.value))) {
-                    var parent_source = patch_location_of_location(s, source_of_edge(s, parent))
-                    var upper_live_patch : patch = connect(s, parent_source, new_patch_node)
-                    ps = [upper_live_patch, ...ps];
-                }
-                return [ps, ls]
-            }
-            else {
-                throw new Error("todo")
-            }
-        case "paste": 
-            var clip = ls.clipboard;
-            if (clip === undefined) return noop
-            if (c.kind === "node") return noop
-            if (clip.kind === "node") {
-                var ps = delete_node(s, clip.value)
-                return [[connect_existing(s, c.value, clip.value), ...ps], {"cursor" : c, "clipboard" : undefined}]
-            }
-            else {
-                var source = patch_location_of_location(s, c.value);
-                var children = live_children_of_location(s, clip.value);
-                var deletion_patches = delete_location(s, clip.value);
-                var live_patches = children.map(e => connect(s, source, patch_node_of_node(s, destination_of_edge(s, e))))
-                var ps = deletion_patches.concat(live_patches);
-                return [ps, {"cursor" : c, "clipboard" : undefined}]
-            }
-    }
-}
+function patches_of_action(
+  cs: client_state,
+  a: action,
+): [patch[], local_state] {
+  var s = cs.shared_state;
+  var ls = cs.local_state;
+  var c = ls.cursor;
+  const noop: [patch[], local_state] = [[], ls];
+  switch (a.kind) {
+    case "move":
+      return noop;
+    case "copy":
+      return noop;
+    case "delete":
+      if (c.kind === "node") {
+        var ps = delete_node(s, c.value);
+        var live_parents = filter_live(s, parents_of_node(s, c.value));
+        if (live_parents.length === 0)
+          throw new Error("Selected node has no live parents");
+        var location = source_of_edge(s, live_parents[0]);
+        return [
+          ps,
+          {
+            cursor: { kind: "location", value: location },
+            clipboard: ls.clipboard,
+          },
+        ];
+      } else {
+        var ps = delete_location(s, c.value);
+        return [ps, ls];
+      }
+    case "insert":
+      if (c.kind === "node") return noop;
+      var children = live_children_of_location(s, c.value);
+      if (children.length > 0) return noop;
+      var new_node = get_new_node();
+      var new_patch_node: patch_node = [new_node, a.value];
+      var source: patch_location = patch_location_of_location(s, c.value);
+      var patch: patch = connect(s, source, new_patch_node);
+      return [[patch], ls];
+    case "wrap_left":
+      if (arity(a.value) === 0) return noop;
+      if (c.kind === "node") {
+        var new_node = get_new_node();
+        var new_patch_node: patch_node = [new_node, a.value];
+        var new_source: patch_location = [new_patch_node, 0];
+        var new_desintation: patch_node = patch_node_of_node(s, c.value);
+        var lower_live_patch: patch = connect(s, new_source, new_desintation);
+        var deletion_patches = delete_node(s, c.value);
+        ps = [lower_live_patch, ...deletion_patches];
 
-function apply_movement(s : state, c : cursor, d : direction) : cursor {
-    if(d === "up") {
-        if(c.kind === "node") {
-            var parent = parent_of_node(s, c.value);
-            if(parent !== undefined) {
-                var source = source_of_edge(s, parent);
-                return {kind: "location", value: source};
-            }
-        } else {
-            if (c.value[0] !== s.root) return {kind:"node", value: c.value[0]}
+        for (var parent of filter_live(s, parents_of_node(s, c.value))) {
+          var parent_source = patch_location_of_location(
+            s,
+            source_of_edge(s, parent),
+          );
+          var upper_live_patch: patch = connect(
+            s,
+            parent_source,
+            new_patch_node,
+          );
+          ps = [upper_live_patch, ...ps];
         }
-    } else if(d === "down") {
-        if(c.kind === "node") {
-            var children_list = children_of_node(s, c.value);
-            if(children_list.length > 0) return {kind: "location", value: [c.value, 0]};
-        } else {
-            var children = live_children_of_location(s, c.value);
-            if(children.length === 0) return c;
-            var child_n = destination_of_edge(s, children[0]); 
-            return {kind:"node", value: child_n}
-        }
-    } else if(d === "right") {
-        if(c.kind === "node") {
-            return {kind: "node", value: right_sibling_of_node(s, c.value)};
-        } else {
-            return {kind: "location", value: right_sibling_of_location(s, c.value)}
-        }
-    }
-    return c
+        return [ps, ls];
+      } else {
+        throw new Error("todo");
+      }
+    case "paste":
+      var clip = ls.clipboard;
+      if (clip === undefined) return noop;
+      if (c.kind === "node") return noop;
+      if (clip.kind === "node") {
+        var ps = delete_node(s, clip.value);
+        return [
+          [connect_existing(s, c.value, clip.value), ...ps],
+          { cursor: c, clipboard: undefined },
+        ];
+      } else {
+        var source = patch_location_of_location(s, c.value);
+        var children = live_children_of_location(s, clip.value);
+        var deletion_patches = delete_location(s, clip.value);
+        var live_patches = children.map((e) =>
+          connect(s, source, patch_node_of_node(s, destination_of_edge(s, e))),
+        );
+        var ps = deletion_patches.concat(live_patches);
+        return [ps, { cursor: c, clipboard: undefined }];
+      }
+  }
 }
 
-export function apply_action(cs : client_state, a : action) : patch[] {
-    var s = cs.shared_state;
-    var ls = cs.local_state;
-    var [ps , ls] = patches_of_action(cs, a);
-    var c = ls.cursor;
-    var clip = ls.clipboard;
-    for (var p of ps) apply_patch(s, p);
-    if (a.kind === "move") c = apply_movement(s, c, a.value);
-    if (a.kind === "copy") clip = c
-    cs =  {shared_state: s, local_state: {cursor: c, clipboard: clip}};
+function apply_movement(s: state, c: cursor, d: direction): cursor {
+  if (d === "up") {
+    if (c.kind === "node") {
+      var parent = parent_of_node(s, c.value);
+      if (parent !== undefined) {
+        var source = source_of_edge(s, parent);
+        return { kind: "location", value: source };
+      }
+    } else {
+      if (c.value[0] !== s.root) return { kind: "node", value: c.value[0] };
+    }
+  } else if (d === "down") {
+    if (c.kind === "node") {
+      var children_list = children_of_node(s, c.value);
+      if (children_list.length > 0)
+        return { kind: "location", value: [c.value, 0] };
+    } else {
+      var children = live_children_of_location(s, c.value);
+      if (children.length === 0) return c;
+      var child_n = destination_of_edge(s, children[0]);
+      return { kind: "node", value: child_n };
+    }
+  } else if (d === "right") {
+    if (c.kind === "node") {
+      return { kind: "node", value: right_sibling_of_node(s, c.value) };
+    } else {
+      return { kind: "location", value: right_sibling_of_location(s, c.value) };
+    }
+  }
+  return c;
+}
 
-    console.log("\nAction: " + a);
-    console.log("patches: " + ps.length);
-    console.log("state: " + string_of_state(cs));
-    console.log("root: " +JSON.stringify(s.root))
-    console.log("cursor: " +JSON.stringify(c.value))
-    console.log("nodes: " + string_of_map(s.constructor));
-    console.log("edges: " + string_of_map(s.sign));
-    console.log("sources: " + string_of_map(s.source));
-    console.log("destinations: " + string_of_map(s.destination));
+export function apply_action(
+  cs: client_state,
+  a: action,
+): { patches: patch[]; local_state: local_state } {
+  var s = cs.shared_state;
+  var ls = cs.local_state;
+  var [ps, ls] = patches_of_action(cs, a);
+  var c = ls.cursor;
+  var clip = ls.clipboard;
+  for (var p of ps) apply_patch(s, p);
+  if (a.kind === "move") c = apply_movement(s, c, a.value);
+  if (a.kind === "copy") clip = c;
+  cs = { shared_state: s, local_state: { cursor: c, clipboard: clip } };
 
-    return ps
+  console.log("\nAction: " + a);
+  console.log("patches: " + ps.length);
+  console.log("state: " + string_of_state(cs));
+  console.log("root: " + JSON.stringify(s.root));
+  console.log("cursor: " + JSON.stringify(c.value));
+  console.log("nodes: " + string_of_map(s.constructor));
+  console.log("edges: " + string_of_map(s.sign));
+  console.log("sources: " + string_of_map(s.source));
+  console.log("destinations: " + string_of_map(s.destination));
+
+  return { patches: ps, local_state: cs.local_state };
 }

--- a/src/grove.ts
+++ b/src/grove.ts
@@ -1,14 +1,20 @@
 // import { Children } from "react";
+import { v4 as uuidv4 } from 'uuid';
 
-type node = {node_id: number};
-type edge = {edge_id: number};
+type NodeId = string & { __brand: 'NodeId' }
+type EdgeId = string & { __brand: 'EdgeId' }
 
-function min_node(n1 : node, n2 : node): node {
-    return {node_id: Math.min(n1.node_id, n2.node_id)};
+const ROOT_NODE_ID = "ROOT" as NodeId;
+
+function min_node(n1 : NodeId, n2 : NodeId): NodeId {
+    if (n1 < n2) {
+        return n1;
+    }
+    return n2;
 }
 
 type position = number;
-type location = [node, position]
+type location = [NodeId, position]
 
 function location_equal(l1 : location, l2 : location): boolean {
     return l1[0] === l2[0] && l1[1] == l2[1]
@@ -31,8 +37,8 @@ function arity(c : constructor): position {
     }
 }
 
-type nodemap<A> = Map<node, A>
-type edgemap<A> = Map<edge, A>
+type nodemap<A> = Map<NodeId, A>
+type edgemap<A> = Map<EdgeId, A>
 
 function string_of_map<K, V>(m: Map<K, V>): string {
   return Array.from(m)
@@ -45,47 +51,39 @@ function string_of_map<K, V>(m: Map<K, V>): string {
 // }
 
 type state = {
-    // replace with uid
-    max_node : node; 
-    max_edge : edge;
-    // 
-    root: node;
-    parents: nodemap<edge[]>
-    children: nodemap<edge[][]>
+    root: NodeId
+    parents: nodemap<EdgeId[]>
+    children: nodemap<EdgeId[][]>
     constructor: nodemap<constructor>
     source: edgemap<location>
-    destination: edgemap<node>
+    destination: edgemap<NodeId>
     sign: edgemap<sign>
     // incremental decomp
     is_root : nodemap<boolean>
     in_unicycle : nodemap<boolean>
 }
 
-function get_new_edge(s : state) : edge {
-    var edge = s.max_edge;
-    s.max_edge = {edge_id: s.max_edge.edge_id + 1};
-    return edge; 
+function get_new_edge() : EdgeId {
+  return uuidv4() as EdgeId;
 }
 
-function get_new_node(s : state) : node {
-    var node = s.max_node;
-    s.max_node = {node_id: s.max_node.node_id + 1};
-    return node; 
+function get_new_node() : NodeId {
+  return uuidv4() as NodeId;
 }
 
-function is_root_of_node(s : state, n : node): boolean {
+function is_root_of_node(s : state, n : NodeId): boolean {
     const is_root = s.is_root.get(n);
     if (is_root === undefined) throw new Error("Node without is_root");
     return is_root;
 }
 
-function in_unicycle_of_node(s : state, n : node): boolean {
+function in_unicycle_of_node(s : state, n : NodeId): boolean {
     const in_unicycle = s.in_unicycle.get(n);
     if (in_unicycle === undefined) throw new Error("Node without in_unicycle");
     return in_unicycle;
 }
 
-function filter_live(s : state, es : edge[]) : edge[] {
+function filter_live(s : state, es : EdgeId[]) : EdgeId[] {
     return es.filter(e => sign_of_edge(s, e) === "live");
 }
 
@@ -93,44 +91,44 @@ function filter_live(s : state, es : edge[]) : edge[] {
 //     return sign_of_edge(s, e) === "live" && !is_root_of_node(s, destination_of_edge(s, e))
 // }
 
-function filter_visible(s : state, es : edge[]) : edge[] {
+function filter_visible(s : state, es : EdgeId[]) : EdgeId[] {
     return es.filter(e => sign_of_edge(s, e) === "live");
 }
 
 
-function parents_of_node(s : state, n : node): edge[] {
+function parents_of_node(s : state, n : NodeId): EdgeId[] {
     const parents = s.parents.get(n);
     if (parents === undefined) throw new Error("Node without parents");
     return parents;
 }
 
-function parent_of_node(s : state, n : node): edge | undefined {
+function parent_of_node(s : state, n : NodeId): EdgeId | undefined {
     var parents = parents_of_node(s, n);
     var live_parents = filter_live(s, parents);
     if (live_parents.length === 1) return live_parents[0];
     return undefined
 }
 
-function unique_parent_of_node(s : state, n : node): edge {
+function unique_parent_of_node(s : state, n : NodeId): EdgeId {
     var parent = parent_of_node(s, n);
     if (parent === undefined) throw new Error("Non-unique parent of node")
     return parent
 }
 
-function children_of_node(s : state, n : node): edge[][] {
+function children_of_node(s : state, n : NodeId): EdgeId[][] {
     const children = s.children.get(n);
     if (children === undefined) throw new Error("Node without children");
     return children;
 }
 
-function live_children_of_location(s : state, l : location): edge[] {
+function live_children_of_location(s : state, l : location): EdgeId[] {
     var [n, p] = l;
     var children = children_of_node(s, n);
     if (p > children.length) throw new Error("Illegal location");
     return filter_live(s, children[p]);
 }
 
-function right_sibling_of_node(s : state, n : node): node {
+function right_sibling_of_node(s : state, n : NodeId): NodeId {
     var parent = parent_of_node(s, n);
     if (parent === undefined) return n;
     var source = source_of_edge(s, parent);
@@ -147,35 +145,35 @@ function right_sibling_of_location(s : state, l : location): location {
     return [n, (p + 1) % children.length]
 }
 
-function constructor_of_node(s : state, n : node): constructor {
+function constructor_of_node(s : state, n : NodeId): constructor {
     const constructor = s.constructor.get(n);
     if (constructor === undefined) throw new Error("Node without destination");
     return constructor;
 }
 
-function source_of_edge(s : state, e : edge): location {
+function source_of_edge(s : state, e : EdgeId): location {
     const source = s.source.get(e);
     if (source === undefined) throw new Error("Edge without source");
     return source;
 }
 
-function destination_of_edge(s : state, e : edge): node {
+function destination_of_edge(s : state, e : EdgeId): NodeId {
     const node = s.destination.get(e);
     if (node === undefined) throw new Error("Edge without destination");
     return node;
 }
 
-function sign_of_edge(s : state, e : edge): sign {
+function sign_of_edge(s : state, e : EdgeId): sign {
     const sign = s.sign.get(e);
     if (sign === undefined) throw new Error("Edge without sign");
     return sign;
 }
 
-type patch_node = [node, constructor];
+type patch_node = [NodeId, constructor];
 type patch_location = [patch_node, position]
 
-type patch = {
-    id: edge,
+export type patch = {
+    id: EdgeId,
     source: patch_location,
     destination: patch_node,
     sign: sign,
@@ -189,17 +187,17 @@ function create_patch_node_if_new(s : state, n : patch_node) {
     s.constructor.set(id, c)
 }
 
-function connect_edge_source(s : state, e : edge) {
+function connect_edge_source(s : state, e : EdgeId) {
     var source = source_of_edge(s, e);
     var [n, p] = source;
     var old_children = children_of_node(s, n);
     if (p >= old_children.length) throw new Error("Invalid child position");
-    var map_child = (childEdges : edge[], i : number) => i === p ? [e, ...childEdges] : childEdges;
+    var map_child = (childEdges : EdgeId[], i : number) => i === p ? [e, ...childEdges] : childEdges;
     var new_children = old_children.map(map_child);
     s.children.set(n, new_children);
 }
 
-function connect_edge_destination(s : state, e : edge) {
+function connect_edge_destination(s : state, e : EdgeId) {
     var destination = destination_of_edge(s, e);
     var old_parents = parents_of_node(s, destination);
     s.parents.set(destination, [e, ...old_parents])
@@ -215,7 +213,7 @@ function create_edge(s : state, p : patch) {
     connect_edge_destination(s, p.id);
 }
 
-function root_of_node(s : state, n : node) : node {
+function root_of_node(s : state, n : NodeId) : NodeId {
     if (is_root_of_node(s, n)) return n
     var parent = unique_parent_of_node(s, n)
     return root_of_node(s, source_of_edge(s, parent)[0]);
@@ -223,8 +221,8 @@ function root_of_node(s : state, n : node) : node {
 
 // rolling a node that's now part of a unicycle updates the
 // [is_root] and [in_unicycle] fields for each node in the unicycle.
-function roll(s : state, n : node) {
-    function loop(current_n : node, min_n : node, first : boolean) {
+function roll(s : state, n : NodeId) {
+    function loop(current_n : NodeId, min_n : NodeId, first : boolean) {
         if(current_n !== n || first) {
             s.in_unicycle.set(current_n, true)
             var new_n = source_of_edge(s, unique_parent_of_node(s, current_n))[0];
@@ -239,14 +237,14 @@ function roll(s : state, n : node) {
 // unrolling a node that's no longer part of a unicycle updates the
 // [is_root] and [in_unicycle] fields between
 // [start_n] and its ancestor [end_n].
-function unroll(s : state, start_n : node, end_n : node) {
+function unroll(s : state, start_n : NodeId, end_n : NodeId) {
     s.is_root.set(start_n, false);
     s.in_unicycle.set(start_n, false);
     var next_n = source_of_edge(s, unique_parent_of_node(s, start_n))[0];
     if(start_n !== end_n) unroll(s, next_n, end_n)
 }
 
-function deaden_edge(s : state, e : edge) {
+function deaden_edge(s : state, e : EdgeId) {
     var source = source_of_edge(s, e);
     var destination = destination_of_edge(s, e);
     var parents = filter_live(s, parents_of_node(s, destination));
@@ -259,7 +257,7 @@ function deaden_edge(s : state, e : edge) {
     }
 }
 
-function liven_edge(s : state, e : edge) {
+function liven_edge(s : state, e : EdgeId) {
     var source = source_of_edge(s, e);
     var destination = destination_of_edge(s, e)
     var parents = filter_live(s, parents_of_node(s, destination));
@@ -283,7 +281,7 @@ function liven_edge(s : state, e : edge) {
     }
 }
 
-function apply_patch(s : state, p : patch) {
+export function apply_patch(s : state, p : patch) {
     var old_sign = s.sign.get(p.id);
     if (old_sign === undefined) {
         create_patch_node_if_new(s, p.source[0]);
@@ -300,29 +298,38 @@ function apply_patch(s : state, p : patch) {
     }
 }
 
-export function initial_client_state(): client_state {
-    var s : state = {
-        max_node: {node_id: 0},
-        max_edge: {edge_id: 0},
-        root: {node_id: -1},
-        parents: new Map([[{node_id: -1}, []]]),
-        children: new Map([[{node_id: -1}, [[]]]]),
-        constructor: new Map([[{node_id: -1}, "root"]]),
+export function initial_client_state(): { state: client_state, patches: patch[] } {
+    var s: state = {
+        root: ROOT_NODE_ID,
+        parents: new Map([[ROOT_NODE_ID, []]]),
+        children: new Map([[ROOT_NODE_ID, [[]]]]),
+        constructor: new Map([[ROOT_NODE_ID, "root"]]),
         source: new Map(),
         destination: new Map(),
         sign: new Map(),
-        is_root : new Map([[{node_id: -1}, true]]),
-        in_unicycle : new Map([[{node_id: -1}, false]]),
+        is_root : new Map([[ROOT_NODE_ID, true]]),
+        in_unicycle : new Map([[ROOT_NODE_ID, false]]),
     };
-    var c : cursor = {kind: "node", value: get_new_node(s)};
+    var c : cursor = { kind: "node", value: get_new_node() };
     var p : patch = {
-        id : get_new_edge(s),
+        id : get_new_edge(),
         source: [[s.root, "root"], 0],
         destination: [c.value, "zero"],
         sign: "live",
     }
-    apply_patch(s, p);
-    return {shared_state: s, local_state: {cursor: c, clipboard: undefined}}
+    apply_patch(s, p)
+    return {
+      state: { shared_state: s, local_state: { cursor: c, clipboard: undefined } },
+      patches: [p],
+    }
+}
+
+export function from_patches(patches: patch[]) : client_state {
+    const { state } = initial_client_state()
+    for (const patch of patches) {
+      apply_patch(state.shared_state, patch)
+    }
+    return state
 }
 
 const cursor_single : string =  "🫵";
@@ -438,7 +445,7 @@ function delete_location(s : state, l : location) : patch[] {
 
 function connect(s : state, source : patch_location, destination : patch_node) : patch {
     return {
-        id: get_new_edge(s),
+        id: get_new_edge(),
         source: source,
         destination: destination,
         sign: "live"
@@ -474,7 +481,7 @@ function patches_of_action(cs : client_state, a : action) : [patch[], local_stat
             if (c.kind === "node") return noop;
             var children = live_children_of_location(s, c.value);
             if (children.length > 0) return noop;
-            var new_node = get_new_node(s);
+            var new_node = get_new_node();
             var new_patch_node : patch_node = [new_node, a.value];
             var source : patch_location = patch_location_of_location(s, c.value)
             var patch : patch = connect(s, source, new_patch_node)
@@ -482,7 +489,7 @@ function patches_of_action(cs : client_state, a : action) : [patch[], local_stat
         case "wrap_left": 
             if (arity(a.value) === 0) return noop;
             if (c.kind === "node") {
-                var new_node = get_new_node(s);
+                var new_node = get_new_node();
                 var new_patch_node : patch_node = [new_node, a.value];
                 var new_source : patch_location = [new_patch_node, 0];
                 var new_desintation : patch_node = patch_node_of_node(s, c.value)
@@ -550,7 +557,7 @@ function apply_movement(s : state, c : cursor, d : direction) : cursor {
     return c
 }
 
-export function apply_action(cs : client_state, a : action) : client_state {
+export function apply_action(cs : client_state, a : action) : patch[] {
     var s = cs.shared_state;
     var ls = cs.local_state;
     var [ps , ls] = patches_of_action(cs, a);
@@ -571,5 +578,5 @@ export function apply_action(cs : client_state, a : action) : client_state {
     console.log("sources: " + string_of_map(s.source));
     console.log("destinations: " + string_of_map(s.destination));
 
-    return cs;
+    return ps
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,48 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
+import {
+  DocHandle,
+  ImmutableString,
+  IndexedDBStorageAdapter,
+  isValidAutomergeUrl,
+  Repo,
+  RepoContext,
+  WebSocketClientAdapter,
+} from "@automerge/react";
+import { initial_client_state } from "./grove.ts";
+import { groveToAutomerge } from "./autogrove.ts";
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+const repo = new Repo({
+  storage: new IndexedDBStorageAdapter(),
+  network: [new WebSocketClientAdapter("wss://sync.automerge.org")],
+});
+
+// @ts-expect-error for debugging
+window.repo = repo;
+
+let handle: DocHandle<{ grovePatches: Record<string, ImmutableString> }>;
+// Check the URL for a document to load
+const locationHash = document.location.hash.substring(1);
+// Depending if we have an AutomergeUrl, either find or create the document
+if (isValidAutomergeUrl(locationHash)) {
+  handle = await repo.find(locationHash);
+} else {
+  // Initialize the document with the genesis patch
+  handle = repo.create({ grovePatches: {} });
+  const { patches } = initial_client_state();
+  groveToAutomerge(patches, handle);
+  // Set the location hash to the new document we just made.
+  document.location.hash = handle.url;
+}
+// @ts-expect-error for debugging
+window.handle = handle;
+
+createRoot(document.getElementById("root")!).render(
+  <RepoContext.Provider value={repo}>
+    <StrictMode>
+      <App handle={handle} />
+    </StrictMode>
+  </RepoContext.Provider>,
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,9 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import wasm from "vite-plugin-wasm";
+import topLevelAwait from "vite-plugin-top-level-await";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+  plugins: [wasm(), topLevelAwait(), react()],
+});


### PR DESCRIPTION
This commit adds collaboration using Automerge. The approach here is to use the automerge document as a simple log of the grove patches, details on the reasoning behind this are in the README.md.

In order to make this work accross devices I had to change the ID generation to use UUIDs. The changes to `src/grove.ts` should be  fairly mechanical. I also had to modify the `initial_client_state` function to return the patches used to create the state as well as the state itself so that those patches could be written to the automerge document.

I have noticed when testing this across browsers that there are some bugs where the cursor disappears (I think that's what's happening anyway). I don't know if that's a logic bug I've introduced or not.